### PR TITLE
UHF-1709: media library form

### DIFF
--- a/src/Form/HelMapForm.php
+++ b/src/Form/HelMapForm.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\helfi_media_map\Form;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\media_library\Form\AddFormBase;
+use Drupal\media_library\MediaLibraryUiBuilder;
+use Drupal\media_library\OpenerResolverInterface;
+
+/**
+ * {@inheritDoc}
+ */
+class HelMapForm extends AddFormBase {
+
+  /**
+   * Constructs a AddFormBase object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\media_library\MediaLibraryUiBuilder $library_ui_builder
+   *   The media library UI builder.
+   * @param \Drupal\media_library\OpenerResolverInterface $opener_resolver
+   *   The opener resolver.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, MediaLibraryUiBuilder $library_ui_builder, OpenerResolverInterface $opener_resolver) {
+    parent::__construct($entity_type_manager, $library_ui_builder, $opener_resolver);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function buildInputElement(array $form, FormStateInterface $form_state) {
+    $container = [
+      '#type' => 'container',
+    ];
+    $container['helfi_media_map_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Map URL'),
+    ];
+
+    $container['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Add'),
+      '#button_type' => 'primary',
+      '#submit' => ['::addButtonSubmit'],
+      '#ajax' => [
+        'callback' => '::updateFormCallback',
+        'wrapper' => 'media-library-wrapper',
+        // @todo Remove when https://www.drupal.org/project/drupal/issues/2504115 is fixed.
+        'url' => Url::fromRoute('media_library.ui'),
+        'options' => [
+          'query' => $this->getMediaLibraryState($form_state)->all() + [
+            FormBuilderInterface::AJAX_FORM_REQUEST => TRUE,
+          ],
+        ],
+      ],
+    ];
+
+    $form['container'] = $container;
+
+    return $form;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function addButtonSubmit(array $form, FormStateInterface $form_state) {
+    $this->processInputValues([$form_state->getValue('helfi_media_map_url')], $form, $form_state);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getFormId() {
+    return 'helfi_media_map_add_form';
+  }
+
+}

--- a/src/Form/HelMapForm.php
+++ b/src/Form/HelMapForm.php
@@ -5,6 +5,7 @@ namespace Drupal\helfi_media_map\Form;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\media_library\Form\AddFormBase;
 use Drupal\media_library\MediaLibraryUiBuilder;
@@ -38,7 +39,11 @@ class HelMapForm extends AddFormBase {
     ];
     $container['helfi_media_map_url'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Map URL'),
+      '#title' => $this->t('Map embed URL'),
+      '#description' => $this->t('Enter the map embed URL from @kartta or @palvelukartta.', [
+        '@kartta' => Link::fromTextAndUrl('https://kartta.hel.fi/', Url::fromUri('https://kartta.hel.fi/', ['attributes' => ['target' => '_blank']]))->toString(),
+        '@palvelukartta' => Link::fromTextAndUrl('https://palvelukartta.hel.fi/fi/', Url::fromUri('https://palvelukartta.hel.fi/fi/', ['attributes' => ['target' => '_blank']]))->toString(),
+      ]),
     ];
 
     $container['submit'] = [

--- a/src/Form/HelfiMediaMapAddForm.php
+++ b/src/Form/HelfiMediaMapAddForm.php
@@ -14,7 +14,7 @@ use Drupal\media_library\OpenerResolverInterface;
 /**
  * {@inheritDoc}
  */
-class HelMapForm extends AddFormBase {
+class HelfiMediaMapAddForm extends AddFormBase {
 
   /**
    * Constructs a AddFormBase object.

--- a/src/Form/HelfiMediaMapAddForm.php
+++ b/src/Form/HelfiMediaMapAddForm.php
@@ -1,34 +1,19 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\helfi_media_map\Form;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\media_library\Form\AddFormBase;
-use Drupal\media_library\MediaLibraryUiBuilder;
-use Drupal\media_library\OpenerResolverInterface;
 
 /**
  * {@inheritDoc}
  */
 class HelfiMediaMapAddForm extends AddFormBase {
-
-  /**
-   * Constructs a AddFormBase object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\media_library\MediaLibraryUiBuilder $library_ui_builder
-   *   The media library UI builder.
-   * @param \Drupal\media_library\OpenerResolverInterface $opener_resolver
-   *   The opener resolver.
-   */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, MediaLibraryUiBuilder $library_ui_builder, OpenerResolverInterface $opener_resolver) {
-    parent::__construct($entity_type_manager, $library_ui_builder, $opener_resolver);
-  }
 
   /**
    * {@inheritDoc}

--- a/src/Plugin/media/Source/Map.php
+++ b/src/Plugin/media/Source/Map.php
@@ -15,6 +15,9 @@ use Drupal\media\MediaTypeInterface;
  *   label = @Translation("Map - palvelukartta.hel.fi and kartta.hel.fi"),
  *   allowed_field_types = {"link"},
  *   description = @Translation("Provides business logic and metadata for Helsinki maps."),
+ *   forms = {
+ *     "media_library_add" = "Drupal\helfi_media_map\Form\HelMapForm"
+ *   }
  * )
  */
 final class Map extends MediaSourceBase {

--- a/src/Plugin/media/Source/Map.php
+++ b/src/Plugin/media/Source/Map.php
@@ -16,7 +16,7 @@ use Drupal\media\MediaTypeInterface;
  *   allowed_field_types = {"link"},
  *   description = @Translation("Provides business logic and metadata for Helsinki maps."),
  *   forms = {
- *     "media_library_add" = "Drupal\helfi_media_map\Form\HelMapForm"
+ *     "media_library_add" = "Drupal\helfi_media_map\Form\HelfiMediaMapAddForm"
  *   }
  * )
  */


### PR DESCRIPTION
Adds a "Map URL" field to the "Add or select media" dialog when adding a new Map media type on a node.

How to test:

- Add a new node (https://helfi.docker.so/en/node/add/page)
- Add Map paragraph to Upper content region
- Click "Add media"
- Add a map embed code from https://kartta.hel.fi/ to the "Map URL" field and click "Add"
- Enter a more descriptive name for the added media item in the next dialog and click "Save"
- See the new item in the list of map items