### PR TITLE
UHF-2053: map embed url maxlength from 128 to 2048

### DIFF
--- a/src/Form/HelfiMediaMapAddForm.php
+++ b/src/Form/HelfiMediaMapAddForm.php
@@ -29,6 +29,7 @@ class HelfiMediaMapAddForm extends AddFormBase {
         '@kartta' => Link::fromTextAndUrl('https://kartta.hel.fi/', Url::fromUri('https://kartta.hel.fi/', ['attributes' => ['target' => '_blank']]))->toString(),
         '@palvelukartta' => Link::fromTextAndUrl('https://palvelukartta.hel.fi/fi/', Url::fromUri('https://palvelukartta.hel.fi/fi/', ['attributes' => ['target' => '_blank']]))->toString(),
       ]),
+      '#maxlength' => 2048,
     ];
 
     $container['submit'] = [


### PR DESCRIPTION
How to test:

- checkout this branch of the module: `composer require drupal/helfi_media_map:dev-UHF-2053_map_embed_url_maxlength`
- add a map embed on a page:
  - Add/edit a content page
  - Select "Add Map" on some of the content areas
  - Click "Add media"
  - In the modal, inspect the text field labeled "Map embed URL" and see that `maxlength=2048`