### PR TITLE
UHF-7927: Map URL validation

### DIFF
--- a/src/Form/HelfiMediaMapAddForm.php
+++ b/src/Form/HelfiMediaMapAddForm.php
@@ -9,6 +9,8 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\media_library\Form\AddFormBase;
+use Drupal\helfi_media_map\Plugin\media\Source\Map;
+use League\Uri\Http;
 
 /**
  * {@inheritDoc}
@@ -53,6 +55,28 @@ class HelfiMediaMapAddForm extends AddFormBase {
     $form['container'] = $container;
 
     return $form;
+  }
+
+  /**
+   * Validates the map url.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return void|TRUE
+   */
+  public function validateMapUrl(array &$form, FormStateInterface $form_state) {
+    $url = $form_state->getValue('helfi_media_map_url');
+    $host = Http::createFromString($url)->getHost();
+
+    if (!in_array($host, Map::VALID_URLS)) {
+      $form_state->setErrorByName('url', $this->t('Given host @host is not valid, must be one of: @domains', [
+        '@host' => $host,
+        '@domains' => implode(', ', Map::VALID_URLS),
+      ]));
+    }
   }
 
   /**

--- a/src/Form/HelfiMediaMapAddForm.php
+++ b/src/Form/HelfiMediaMapAddForm.php
@@ -39,6 +39,7 @@ class HelfiMediaMapAddForm extends AddFormBase {
       '#value' => $this->t('Add'),
       '#button_type' => 'primary',
       '#submit' => ['::addButtonSubmit'],
+      '#validate' => ['::validateMapUrl'],
       '#ajax' => [
         'callback' => '::updateFormCallback',
         'wrapper' => 'media-library-wrapper',


### PR DESCRIPTION
# [UHF-7927](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7927)

When user adds a map from unsupported host while adding a map paragraph, the media library view doesn't work. Solution is to validate the URL. 

## What was done

* Added validation for the map URL when adding new map via the map paragraph's media browser view.

## How to install

* Have some instance, where this module is enabled and used, running.
* Use the code from this branch in your instance: `composer require drupal/helfi_media_map:dev-UHF-7927_map-url-validation`

## How to test

* [x] Go to node add/edit of a standard page and add a map paragraph.
* [x] Open the media browser for adding a map to the paragraph. For "Map embed URL" field, give some URL, e.g. https://maps.google.com, and click Add. It should give an error.
* [x] Try that valid URLs work: https://kartta.hel.fi/ and https://palvelukartta.hel.fi/fi/.

## Designers review

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

[UHF-7927]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ